### PR TITLE
Add pythonic and Normal way of calculating cartesian product

### DIFF
--- a/Normal way/cartesianProduct.py
+++ b/Normal way/cartesianProduct.py
@@ -1,0 +1,15 @@
+# Cartesian product
+A = [1, 2, 3]
+B = [5, 7, 2]
+
+cartesian_product = []
+
+for x in A:
+	for y in B:
+		pair = (x, y)
+		cartesian_product.append(pair)
+
+print(cartesian_product)
+
+# Result
+# [(1, 5), (1, 7), (1, 2), (2, 5), (2, 7), (2, 2), (3, 5), (3, 7), (3, 2)]

--- a/Pythonic way/cartesianProduct.py
+++ b/Pythonic way/cartesianProduct.py
@@ -1,0 +1,20 @@
+# Cartesian product
+
+A = [1, 2, 3]
+B = [5, 7, 2]
+
+# using list comprehension
+cartesian_product = [(x, y) for x in A for y in B]
+print(cartesian_product)
+
+# cartesian product using built-in function
+def cartesianProduct(A, B):
+	import itertools
+	p = itertools.product(A, B) # p is a itertools.product object
+	cartesian_product = list(p)
+	return cartesian_product
+
+print(cartesianProduct(A, B))
+
+# Result
+# [(1, 5), (1, 7), (1, 2), (2, 5), (2, 7), (2, 2), (3, 5), (3, 7), (3, 2)]

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Please check the [contribution guidelines](./CONTRIBUTING.md) for more informati
 | 15         |   Swapping Variables   |                      [swappingVars.py](/Normal%20way/swappingVars.py)                      |                      [swappingVars.py](/Pythonic%20way/swappingVars.py)                      |
 | 16         |   Frequency of Words   |                     [wordFrequency.py](/Normal%20way/wordFrequency.py)                     |                     [wordFrequency.py](/Pythonic%20way/wordFrequency.py)                     |
 | 17         |   Print String N Times   |                     [printStringNTimes.py](/Normal%20way/printStringNTimes.py)                     |                     [printStringNTimes.py](/Pythonic%20way/printStringNTimes.py)                     |
-
+| 18         |   Calculate Cartesian Product   |                     [cartesianProduct.py](/Normal%20way/cartesianProduct.py)                     |                     [cartesianProduct.py](/Pythonic%20way/cartesianProduct.py)                     |
 
 
 **Contributions are welcome!**

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Please check the [contribution guidelines](./CONTRIBUTING.md) for more informati
 | 16         |   Frequency of Words   |                     [wordFrequency.py](/Normal%20way/wordFrequency.py)                     |                     [wordFrequency.py](/Pythonic%20way/wordFrequency.py)                     |
 | 17         |   Print String N Times   |                     [printStringNTimes.py](/Normal%20way/printStringNTimes.py)                     |                     [printStringNTimes.py](/Pythonic%20way/printStringNTimes.py)                     |
 | 18         |   Transpose Of a Matrix   |                     [transposeMatrix.py](/Normal%20way/transposeMatrix.py)                     |                     [transposeMatrix.py](/Pythonic%20way/transposeMatrix.py)                     |
-| 18         |   Calculate Cartesian Product   |                     [cartesianProduct.py](/Normal%20way/cartesianProduct.py)                     |                     [cartesianProduct.py](/Pythonic%20way/cartesianProduct.py)                     |
+| 19         |   Calculate Cartesian Product   |                     [cartesianProduct.py](/Normal%20way/cartesianProduct.py)                     |                     [cartesianProduct.py](/Pythonic%20way/cartesianProduct.py)                     |
 
 
 **Contributions are welcome!**


### PR DESCRIPTION
Normal way uses **_nested loops_** to to generate all pairs 
Python way uses _**list comprehension**_ as well as built-in function in _**itertools**_ module
name of the file -  `cartesianProduct.py`

**Example of cartesian product**
A = [1, 2, 3]
B = [4, 5]
Cartesian product of A and B _**A X B**_ is **_[(1, 4), (1, 5), (2, 4), (2, 5), (3, 4), (3, 5)]_**

### Pull Request checklist

- [ ] bug fix

- [ ] feature

- [x] enhancement